### PR TITLE
"better" support for "long-only" arguments

### DIFF
--- a/src/sarge.cpp
+++ b/src/sarge.cpp
@@ -183,6 +183,6 @@ void Sarge::printHelp() {
 	// Print out the options.
 	std::vector<std::unique_ptr<Argument> >::const_iterator it;
 	for (it = args.cbegin(); it != args.cend(); ++it) {
-		std::cout << "-" << (*it)->arg_short << "\t--" << (*it)->arg_long << "\t\t" << (*it)->description << std::endl;
+		std::cout << ((*it)->arg_short != "" ? "-" : "") << (*it)->arg_short << "\t--" << (*it)->arg_long << "\t\t" << (*it)->description << std::endl;
 	}
 }

--- a/src/sarge.cpp
+++ b/src/sarge.cpp
@@ -180,9 +180,17 @@ void Sarge::printHelp() {
 	std::cout << std::endl;
 	std::cout << "Options: " << std::endl;
 	
+    // determine whitespaces needed between art_long and description
+    int count = 1; 
+    std::vector<std::unique_ptr<Argument> >::const_iterator it;
+    for (it = args.cbegin(); it != args.cend(); ++it)
+        if ((*it)->arg_long.size() > count) count = (*it)->arg_long.size();
+    count += 3; // number of actual spaces between the longest arg_long and description
+
 	// Print out the options.
-	std::vector<std::unique_ptr<Argument> >::const_iterator it;
-	for (it = args.cbegin(); it != args.cend(); ++it) {
-		std::cout << ((*it)->arg_short != "" ? "-" : "") << (*it)->arg_short << "\t--" << (*it)->arg_long << "\t\t" << (*it)->description << std::endl;
+	for (it = args.cbegin(); it != args.cend(); ++it)
+    {
+		std::cout << ((*it)->arg_short != "" ? "-" + (*it)->arg_short + ", " : "    ") << "--" << (*it)->arg_long;
+        std::cout << std::string(count - (*it)->arg_long.size(), ' ') << (*it)->description << std::endl;
 	}
 }

--- a/src/sarge.cpp
+++ b/src/sarge.cpp
@@ -180,17 +180,17 @@ void Sarge::printHelp() {
 	std::cout << std::endl;
 	std::cout << "Options: " << std::endl;
 	
-    // determine whitespaces needed between art_long and description
-    int count = 1; 
-    std::vector<std::unique_ptr<Argument> >::const_iterator it;
-    for (it = args.cbegin(); it != args.cend(); ++it)
-        if ((*it)->arg_long.size() > count) count = (*it)->arg_long.size();
-    count += 3; // number of actual spaces between the longest arg_long and description
+	// determine whitespaces needed between art_long and description
+	int count = 1; 
+	std::vector<std::unique_ptr<Argument> >::const_iterator it;
+	for (it = args.cbegin(); it != args.cend(); ++it)
+		if ((*it)->arg_long.size() > count) count = (*it)->arg_long.size();
+	count += 3; // number of actual spaces between the longest arg_long and description
 
 	// Print out the options.
 	for (it = args.cbegin(); it != args.cend(); ++it)
-    {
+	{
 		std::cout << ((*it)->arg_short != "" ? "-" + (*it)->arg_short + ", " : "    ") << "--" << (*it)->arg_long;
-        std::cout << std::string(count - (*it)->arg_long.size(), ' ') << (*it)->description << std::endl;
+		std::cout << std::string(count - (*it)->arg_long.size(), ' ') << (*it)->description << std::endl;
 	}
 }

--- a/src/sarge.cpp
+++ b/src/sarge.cpp
@@ -190,7 +190,7 @@ void Sarge::printHelp() {
 	// Print out the options.
 	for (it = args.cbegin(); it != args.cend(); ++it)
 	{
-		std::cout << ((*it)->arg_short != "" ? "-" + (*it)->arg_short + ", " : "    ") << "--" << (*it)->arg_long;
+		std::cout << ((*it)->arg_short.empty() ? "    " : "-" + (*it)->arg_short + ", ") << "--" << (*it)->arg_long;
 		std::cout << std::string(count - (*it)->arg_long.size(), ' ') << (*it)->description << std::endl;
 	}
 }

--- a/test/sarge_test.cpp
+++ b/test/sarge_test.cpp
@@ -28,6 +28,7 @@ int main(int argc, char** argv) {
 	sarge.setArgument("n", "number", "Gimme a number. Any number.", true);
 	sarge.setArgument("a", "apple", "Just an apple.", false);
 	sarge.setArgument("b", "bear", "Look, it's a bear.", false);
+	sarge.setArgument("", "snake", "Snakes only come in long form, there are no short snakes.", false);
 	sarge.setDescription("Sarge command line argument parsing testing app. For demonstration purposes and testing.");
 	sarge.setUsage("sarge_test <options>");
 	


### PR DESCRIPTION
Dear Maya, thanks so much for this project, I was tinkering with getopt and other libraries but never was completely satisfied with how command line argument parsing was done in our projects. Sarge is the best option so far. 

We sometimes have too much options so we cannot always set short arguments. In that case we have the most common options which have short and long names and also less common options which only have long names. Thankfully Sarge already supports that. But `printHelp()` will then do something not so fancy: it will print a single dash with no option name after it (e.g. option `--snake`)
Also `printHelp()` will print the description after a hard count of tabs which results unevenly spaced (e.g. options `--kittens` and `--number`)

```shell
root@2894fc264af2:/src# bin/sarge_test -hk Mew -n 5
Number of flags found: 3

Sarge command line argument parsing testing app. For demonstration purposes and testing.

Usage:
	sarge_test <options>

Options: 
-h	--help		Get help.
-k	--kittens		K is for kittens. Everyone needs kittens in their life.
-n	--number		Gimme a number. Any number.
-a	--apple		Just an apple.
-b	--bear		Look, it's a bear.
-	--snake		Snakes only come in long form, there are no short snakes.
Got kittens: Mew
Got number: 5
```

This pull request tries to solve those things. It did the following (possibly horrible) things to the code:

- to save space the short and long option name are printed with a `, ` between them, not a `\t`
- in `printHelp()` when a "long-only" option is found do not print the single dash, but instead 4 spaces which should evenly space the following long-name to all the other long-names
- in `printHelp()` instead of a fixed amount of `\t` a dynamic amount of spaces will be printed after the long name so all description are aligned vertically
- add the "long-only" option `--snakes` to the test-file to demonstrate

```shell
root@2894fc264af2:/src# bin/sarge_test -hk Mew -n 5
Number of flags found: 3

Sarge command line argument parsing testing app. For demonstration purposes and testing.

Usage:
	sarge_test <options>

Options: 
-h, --help      Get help.
-k, --kittens   K is for kittens. Everyone needs kittens in their life.
-n, --number    Gimme a number. Any number.
-a, --apple     Just an apple.
-b, --bear      Look, it's a bear.
    --snake     Snakes only come in long form, there are no short snakes.
Got kittens: Mew
Got number: 5
```

Thanks again for sharing Sarge with us!

Best,
Mathias
