### PR TITLE
Added CMakeLists.txt for building sarge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(sarge)
+
+option(BUILD_SHARED_LIBS "Build shared library." OFF)
+
+ADD_LIBRARY(sarge src/sarge.cpp)
+add_library(sarge::sarge ALIAS sarge)
+
+target_include_directories(sarge
+        PUBLIC ${PROJECT_SOURCE_DIR}/src
+)


### PR DESCRIPTION
This is how we use sarge:

    target_link_libraries(mytarget PUBLIC sarge::sarge)

As CMake documentation says, this will add sarge include dirs PUBLIC into the compiler / linker. And one can then just use it like:

#include <sarge.h>

... use it