### PR TITLE
Adds support for multiple command line parsers

### DIFF
--- a/src/sarge.h
+++ b/src/sarge.h
@@ -38,8 +38,10 @@ class Sarge {
 	std::string description;
 	std::string usage;
 	std::vector<std::string> textArguments;
+  bool permissive = false;
 	
 public:
+  Sarge(bool permissive_ = false);
 	void setArgument(std::string arg_short, std::string arg_long, std::string desc, bool hasVal);
 	void setArguments(std::vector<Argument> args);
 	void setDescription(std::string desc) { this->description = desc; }


### PR DESCRIPTION
When one wants to use Sarge with GUnit in parallel one could have something like this:

    ./mybinary --sargeflag foo --gunit_filter="mytests.test123"

But then the normal Sarge would return false on parseArguments().

With this new flag added to the Sarge constructor it will tolerate flags which are not coming from sarge and ignore them. This is how we use it in our code ATM and it works so far.

